### PR TITLE
fix: do not remove whitespace when listing oneOf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.DS_Store
 node_modules
+test/output

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ If you don't have the AsyncAPI Generator installed, you can install it like this
 npm install -g @asyncapi/generator
 ```
 
+## Development
+
+1. Make sure you have the latest generator installed `npm install -g @asyncapi/generator`.
+1. Modify the template or it's helper functions. Adjust `test/spec/asyncapi.yml` to have more features if needed.
+1. Generate output with watcher enables `npm run develop`.
+1. Check generated markdown file located in `./test/output/asyncapi.md`.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "scripts": {
     "test": "echo \"No test specified yet\"",
     "release": "semantic-release",
-    "get-version": "echo $npm_package_version"
+    "get-version": "echo $npm_package_version",
+    "develop": "ag test/spec/asyncapi.yml ./ -o test/output --force-write --watch-template"
   },
   "publishConfig": {
     "access": "public"

--- a/partials/operation.md
+++ b/partials/operation.md
@@ -1,18 +1,18 @@
 {% from "./message.md" import message %}
 
 {% macro operation(op, channelName) %}
-### {% if op.isPublish() %} `publish`{%- endif %}{%- if op.isSubscribe() %} `subscribe`{%- endif %} {{channelName}}
+### {% if op.isPublish() %} `publish`{% endif %}{% if op.isSubscribe() %} `subscribe`{% endif %} {{channelName}}
 
 #### Message
 
 {% if op.hasMultipleMessages() %}
 Accepts **one of** the following messages:
 
-{% for msg in op.messages() -%}
+{% for msg in op.messages() %}
 ##### Message #{{loop.index}}
 {{ message(msg) }}
-{%- endfor -%}
+{% endfor %}
 {% else %}
-{{- message(op.message(0)) -}}
+{{ message(op.message(0)) }}
 {% endif %}
 {% endmacro %}

--- a/partials/operation.md
+++ b/partials/operation.md
@@ -8,7 +8,7 @@
 {% if op.hasMultipleMessages() %}
 Accepts **one of** the following messages:
 
-{%- for msg in op.messages() -%}
+{% for msg in op.messages() -%}
 ##### Message #{{loop.index}}
 {{ message(msg) }}
 {%- endfor -%}

--- a/test/spec/asyncapi.yml
+++ b/test/spec/asyncapi.yml
@@ -1,0 +1,265 @@
+asyncapi: '2.0.0'
+info:
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you to remotely manage the city lights.
+
+    ### Check out its awesome features:
+
+    * Turn a specific streetlight on/off 🌃
+    * Dim a specific streetlight 😎
+    * Receive real-time information about environmental lighting conditions 📈
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  production:
+    url: mqtt://test.mosquitto.org:{port}
+    protocol: mqtt
+    description: Test broker
+    variables:
+      port:
+        description: Secure connection (TLS) is available through port 8883.
+        default: '1883'
+        enum:
+          - '1883'
+          - '8883'
+
+defaultContentType: application/json
+
+channels:
+  smartylighting/streetlights/1/0/event/{streetlightId}/lighting/measured:
+    description: The topic on which measured values may be produced and consumed.
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    publish:
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      operationId: receiveLightMeasurement
+      tags:
+        - name: oparation-tag1
+          externalDocs: 
+            description: External docs description 1
+            url: https://www.asyncapi.com/
+        - name: oparation-tag2
+          description: Description 2
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        - name: oparation-tag3
+        - name: oparation-tag4
+          description: Description 4
+        - name: message-tag5
+          externalDocs:  
+            url: "https://www.asyncapi.com/"
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/lightMeasured'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/on:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOn
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/turn/off:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: turnOff
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/turnOnOff'
+
+  smartylighting/streetlights/1/0/action/{streetlightId}/dim:
+    parameters:
+      streetlightId:
+        $ref: '#/components/parameters/streetlightId'
+    subscribe:
+      operationId: dimLight
+      traits:
+        - $ref: '#/components/operationTraits/kafka'
+      message:
+        $ref: '#/components/messages/dimLight'
+  some.channel:
+    subscribe:
+      description: this doesn't show in markdown!
+      message:
+        oneOf:
+          - $ref: '#/components/messages/successMessage'
+          - $ref: '#/components/messages/failureMessage'
+
+components:
+  messages:
+    lightMeasured:
+      name: lightMeasured
+      title: Light measured
+      summary: Inform about environmental lighting conditions of a particular streetlight.
+      contentType: application/json
+      tags:
+        - name: message-tag1
+          externalDocs: 
+            description: External docs description 1
+            url: https://www.asyncapi.com/
+        - name: message-tag2
+          description: Description 2
+          externalDocs:
+            url: "https://www.asyncapi.com/"
+        - name: message-tag3
+        - name: message-tag4
+          description: Description 4
+        - name: message-tag5
+          externalDocs:  
+            url: "https://www.asyncapi.com/"
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/lightMeasuredPayload"
+    turnOnOff:
+      name: turnOnOff
+      title: Turn on/off
+      summary: Command a particular streetlight to turn the lights on or off.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/turnOnOffPayload"
+    dimLight:
+      name: dimLight
+      title: Dim light
+      summary: Command a particular streetlight to dim the lights.
+      traits:
+        - $ref: '#/components/messageTraits/commonHeaders'
+      payload:
+        $ref: "#/components/schemas/dimLightPayload"
+    successMessage:
+      name: Success
+      payload:
+          type: object
+          properties:
+            result:
+              type: string
+              examples:
+                - success
+    failureMessage:
+      name: Failure
+      payload:
+          type: object
+          properties:
+            error:
+              type: object
+              properties:
+                errorCode:
+                  type: integer              
+                errorMessage:
+                  type: string
+          examples:
+            - error:
+                errorCode: 404
+                errorMessage: Something messed up
+  schemas:
+    lightMeasuredPayload:
+      type: object
+      properties:
+        lumens:
+          type: integer
+          minimum: 0
+          description: Light intensity measured in lumens.
+          x-pi: false
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    turnOnOffPayload:
+      type: object
+      properties:
+        command:
+          type: string
+          enum:
+            - on
+            - off
+          description: Whether to turn on or off the light.
+          x-pi: false
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    dimLightPayload:
+      type: object
+      properties:
+        percentage:
+          type: integer
+          description: Percentage to which the light should be dimmed to.
+          minimum: 0
+          maximum: 100
+        sentAt:
+          $ref: "#/components/schemas/sentAt"
+    sentAt:
+      type: string
+      format: date-time
+      description: Date and time when the message was sent.
+
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      in: user
+      description: Provide your API key as the user and leave the password empty.
+    supportedOauthFlows:
+      type: oauth2
+      description: Flows to support OAuth 2.0
+      flows:
+        implicit:
+          authorizationUrl: 'https://authserver.example/auth'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        password:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        clientCredentials:
+          tokenUrl: 'https://authserver.example/token'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+        authorizationCode:
+          authorizationUrl: 'https://authserver.example/auth'
+          tokenUrl: 'https://authserver.example/token'
+          refreshUrl: 'https://authserver.example/refresh'
+          scopes:
+            'streetlights:on': Ability to switch lights on
+            'streetlights:off': Ability to switch lights off
+            'streetlights:dim': Ability to dim the lights
+    openIdConnectWellKnown:
+      type: openIdConnect
+      openIdConnectUrl: 'https://authserver.example/.well-known'
+
+  parameters:
+    streetlightId:
+      description: The ID of the streetlight.
+      schema:
+        type: string
+
+  messageTraits:
+    commonHeaders:
+      headers:
+        type: object
+        properties:
+          my-app-header:
+            type: integer
+            minimum: 0
+            maximum: 100
+
+  operationTraits:
+    kafka:
+      bindings:
+        kafka:
+          clientId: my-app-id


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- do not remove whitespace when listing oneOf

In general I think we do not need to use this whitespace removal as at the end Markdown parsers do not care if you have 1 or 5 whitespaces, it will just be a separate paragraph anyway. @fmvilas am I missing some use case?

**Related issue(s)**
Fixes #5