### PR TITLE
feat: Add parameter to change output file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ If you don't have the AsyncAPI Generator installed, you can install it like this
 ```
 npm install -g @asyncapi/generator
 ```
+## Supported parameters
+
+|Name|Description|Required|Example|
+|---|---|---|---|
+|outFilename|The filename of the output file. Defaults to `asyncapi.md`|No|`index.md`|
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ npm install -g @asyncapi/generator
 ```
 ## Supported parameters
 
-|Name|Description|Required|Example|
+|Name|Description|Required|Default|Example|
 |---|---|---|---|
-|outFilename|The filename of the output file. Defaults to `asyncapi.md`|No|`index.md`|
+|outFilename|The filename of the output file.|No|`asyncapi.md`|`index.md`|
 
 ## Development
 

--- a/hooks/output-filename.js
+++ b/hooks/output-filename.js
@@ -3,8 +3,8 @@ const fs = require('fs');
 module.exports = {
     'generate:after': generator => {
         if(generator.templateParams.outFilename !== 'asyncapi.md') {
-            fs.rename(`${generator.targetDir}/asyncapi.md`,
-                `${generator.targetDir}/${generator.templateParams.outFilename}`, () => {});
+            fs.renameSync(`${generator.targetDir}/asyncapi.md`,
+                `${generator.targetDir}/${generator.templateParams.outFilename}`);
         }
     }
 }

--- a/hooks/output-filename.js
+++ b/hooks/output-filename.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+
+module.exports = {
+    'generate:after': generator => {
+        if(generator.templateParams.outFilename !== 'asyncapi.md') {
+            fs.rename(`${generator.targetDir}/asyncapi.md`,
+                `${generator.targetDir}/${generator.templateParams.outFilename}`, () => {});
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     ],
     "parameters": {
       "outFilename": {
-        "description": "The name of the output file",
+        "description": "The name of the output markdown file",
         "default": "asyncapi.md",
         "required": false
       }

--- a/package.json
+++ b/package.json
@@ -63,6 +63,13 @@
     "generator": ">=0.50.0 <2.0.0",
     "filters": [
       "@asyncapi/generator-filters"
-    ]
+    ],
+    "parameters": {
+      "outFilename": {
+        "description": "The name of the output file",
+        "default": "asyncapi.md",
+        "required": false
+      }
+    }
   }
 }


### PR DESCRIPTION
**Description**
I added a hook to rename the output file using Node.js `fs` and added the template parameter `outFilename` to do so. The parameter is optional and defaults to `asyncapi.md`.

**Related issue(s)**
Fixes #23 