### PR TITLE
feat: Add message name to header when multiple messages

### DIFF
--- a/partials/operation.md
+++ b/partials/operation.md
@@ -14,7 +14,7 @@
 Accepts **one of** the following messages:
 
 {% for msg in op.messages() -%}
-##### Message #{{loop.index}}
+##### Message `{{ msg.uid() }}`
 {{ message(msg) }}
 {% endfor -%}
 {%- else -%}


### PR DESCRIPTION
**Description**
Changed output to include `message.uid()` rather then the loop index.

**Related issue(s)**
Closes #22 