### PR TITLE
feat: support for YAML frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ npm install -g @asyncapi/generator
 
 |Name|Description|Required|Default|Allowed values|Example|
 |---|---|---|---|---|---|
+|frontMatter|The name of a JSON or YAML formatted file containing values to override the default YAML frontmatter.|No|None|Any JSON or YAML formatted file|`slate.yaml`|
 |outFilename|The filename of the output file.|No|`asyncapi.md`|*Any* with `.md` extension|`index.md`|
+|slate|Include [Slate](https://github/slatedocs/slate) YAML frontmatter in the output markdown. Disables markdown ToC.|No|`false`|`boolean`|`true`|
 |version|Override the version of your application provided under `info.version` location in the specification file.|No|Version is taken from the specification file.|Version is taken from the spec file. |`1.0.0`|
 
 
@@ -29,6 +31,8 @@ npm install -g @asyncapi/generator
 2. Modify the template or it's reusable parts. Adjust `test/spec/asyncapi.yml` to have more complexity if needed.
 3. Generate output with watcher enabled by running the command `npm run dev`.
 4. Check generated markdown file located in `./test/output/asyncapi.md`.
+
+Parameters for the template are defined in `package.json`.
 
 ## Contributors ✨
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ npm install -g @asyncapi/generator
 
 |Name|Description|Required|Default|Allowed values|Example|
 |---|---|---|---|---|---|
-|frontMatter|The name of a JSON or YAML formatted file containing values to override the default YAML frontmatter.|No|None|Any JSON or YAML formatted file|`slate.yaml`|
+|frontMatter|The name of a JSON or YAML formatted file containing values to provide the YAML frontmatter for static-site or documentation generators. The file may contain {{title}} and {{version}} replaceable tags.|No|None|Any JSON or YAML formatted file|`slate.yaml`|
 |outFilename|The filename of the output file.|No|`asyncapi.md`|*Any* with `.md` extension|`index.md`|
-|slate|Include [Slate](https://github/slatedocs/slate) YAML frontmatter in the output markdown. Disables markdown ToC.|No|`false`|`boolean`|`true`|
+|toc|Include a Table-of-Contents in the output markdown.|No|`true`|`boolean`|`false`|
 |version|Override the version of your application provided under `info.version` location in the specification file.|No|Version is taken from the specification file.|Version is taken from the spec file. |`1.0.0`|
 
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install -g @asyncapi/generator
 
 |Name|Description|Required|Default|Allowed values|Example|
 |---|---|---|---|---|---|
-|frontMatter|The name of a JSON or YAML formatted file containing values to provide the YAML frontmatter for static-site or documentation generators. The file may contain {{title}} and {{version}} replaceable tags.|No|None|Any JSON or YAML formatted file|`slate.yaml`|
+|frontMatter|The name of a JSON or YAML formatted file containing values to provide the YAML frontmatter for static-site or documentation generators, just like [this](test/spec/ssg.yaml) one. The file may contain {{title}} and {{version}} tags. They are replaced with information for the AsyncAPI document that is under `info.title` and `info.version`. You can overwrite the version with `version` parameter. [Here](test/spec/slate.yaml) you can see an example that uses tags in frontmatter compatible with [slate](https://github.com/Slatedocs/Slate) |No|None|Any JSON or YAML formatted file|`slate.yaml`|
 |outFilename|The filename of the output file.|No|`asyncapi.md`|*Any* with `.md` extension|`index.md`|
 |toc|Include a Table-of-Contents in the output markdown.|No|`true`|`boolean`|`false`|
 |version|Override the version of your application provided under `info.version` location in the specification file.|No|Version is taken from the specification file.|Version is taken from the spec file. |`1.0.0`|

--- a/components/FrontMatter.js
+++ b/components/FrontMatter.js
@@ -4,21 +4,9 @@ import * as fs from "fs";
 import * as yaml from "yaml";
 
 export function FrontMatter({ asyncapi, params }) {
-  if (!(params.slate || params.frontMatter)) return '';
-
-  let frontMatter;
-  if (params.frontMatter) {
-    frontMatter = yaml.parse(fs.readFileSync(params.frontMatter,'utf8'));
-  } else {
-    frontMatter = {
-      title: asyncapi.info().title(),
-      language_tabs: [],
-      toc_footers: [],
-      includes: [],
-      search: true,
-      code_clipboard: true
-    };
-  }
-  const frontMatterStr = yaml.stringify(frontMatter);
-  return <Text newLines={2}>{`---\n${frontMatterStr}\n---`}</Text>
+  const frontMatter = yaml.parse(fs.readFileSync(params.frontMatter,'utf8'));
+  let frontMatterStr = yaml.stringify(frontMatter);
+  frontMatterStr = frontMatterStr.split('{{title}}').join(asyncapi.info().title());
+  frontMatterStr = frontMatterStr.split('{{version}}').join(params.version || asyncapi.info().version());
+  return <Text newLines={2}>{`---\n${frontMatterStr}---`}</Text>
 }

--- a/components/FrontMatter.js
+++ b/components/FrontMatter.js
@@ -1,0 +1,27 @@
+import { Text } from "@asyncapi/generator-react-sdk";
+
+import * as fs from "fs";
+import * as yaml from "yaml";
+
+export function FrontMatter({ asyncapi, params }) {
+
+  if (!(params.slate || params.frontMatter)) return '';
+
+  const defaultFM = {
+    title: asyncapi.info().title(),
+    language_tabs: [],
+    toc_footers: [],
+    includes: [],
+    search: true,
+    code_clipboard: true
+  };
+
+  let frontMatter;
+  if (params.frontMatter) {
+    frontMatter = yaml.parse(fs.readFileSync(params.frontMatter,'utf8'));
+  }
+
+  const frontMatterStr = yaml.stringify(frontMatter || defaultFM);
+  return <Text newLines={2}>{`---\n${frontMatterStr}\n---`}</Text>
+}
+

--- a/components/FrontMatter.js
+++ b/components/FrontMatter.js
@@ -4,24 +4,21 @@ import * as fs from "fs";
 import * as yaml from "yaml";
 
 export function FrontMatter({ asyncapi, params }) {
-
   if (!(params.slate || params.frontMatter)) return '';
-
-  const defaultFM = {
-    title: asyncapi.info().title(),
-    language_tabs: [],
-    toc_footers: [],
-    includes: [],
-    search: true,
-    code_clipboard: true
-  };
 
   let frontMatter;
   if (params.frontMatter) {
     frontMatter = yaml.parse(fs.readFileSync(params.frontMatter,'utf8'));
+  } else {
+    frontMatter = {
+      title: asyncapi.info().title(),
+      language_tabs: [],
+      toc_footers: [],
+      includes: [],
+      search: true,
+      code_clipboard: true
+    };
   }
-
-  const frontMatterStr = yaml.stringify(frontMatter || defaultFM);
+  const frontMatterStr = yaml.stringify(frontMatter);
   return <Text newLines={2}>{`---\n${frontMatterStr}\n---`}</Text>
 }
-

--- a/components/Message.js
+++ b/components/Message.js
@@ -1,7 +1,7 @@
 import { Text } from "@asyncapi/generator-react-sdk";
 import { generateExample, getHeadersExamples, getPayloadExamples } from "@asyncapi/generator-filters";
 
-import { Header, ListItem, CodeBlock } from "./common";
+import { Header, ListItem, CodeBlock, BlockQuote } from "./common";
 import { Schema } from "./Schema";
 
 export function Message({ message, title = 'Message' }) {
@@ -61,7 +61,7 @@ function Example({ type = 'headers', message }) {
     if (examples) {
       return (
         <>
-          <Header type={6}>Examples of headers</Header>
+          <BlockQuote>Examples of headers</BlockQuote>
           {examples.map(ex => (
             <Text newLines={2}>
               <CodeBlock language='json'>{JSON.stringify(ex, null, 2)}</CodeBlock>
@@ -73,7 +73,7 @@ function Example({ type = 'headers', message }) {
 
     return (
       <>
-        <Header type={6}>Examples of headers _(generated)_</Header>
+        <BlockQuote>Examples of headers _(generated)_</BlockQuote>
         <Text newLines={2}>
           <CodeBlock language='json'>{generateExample(message.headers().json())}</CodeBlock>
         </Text>
@@ -84,7 +84,7 @@ function Example({ type = 'headers', message }) {
     if (examples) {
       return (
         <>
-          <Header type={6}>Examples of payload</Header>
+          <BlockQuote>Examples of payload</BlockQuote>
           {examples.map(ex => (
             <Text newLines={2}>
               <CodeBlock language='json'>{JSON.stringify(ex, null, 2)}</CodeBlock>
@@ -96,7 +96,7 @@ function Example({ type = 'headers', message }) {
 
     return (
       <>
-        <Header type={6}>Examples of payload _(generated)_</Header>
+        <BlockQuote>Examples of payload _(generated)_</BlockQuote>
         <Text newLines={2}>
           <CodeBlock language='json'>{generateExample(message.payload().json())}</CodeBlock>
         </Text>

--- a/components/common.js
+++ b/components/common.js
@@ -52,3 +52,8 @@ export function CodeBlock({ language = 'json', childrenContent = '' }) {
     </Text>
   );
 }
+
+export function BlockQuote({ childrenContent = "" }) {
+  return <Text newLines={2}>{`> ${childrenContent}`}</Text>
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -7689,8 +7689,7 @@
     "yaml": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
-      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
-      "dev": true
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     },
     "yaml-ast-parser": {
       "version": "0.0.43",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "generator": ">=1.1.0 <2.0.0",
     "parameters": {
       "frontMatter": {
-        "description": "The name of a JSON or YAML formatted file containing values to override the default YAML frontmatter.",
+        "description": "The name of a JSON or YAML formatted file containing values to provide the YAML frontmatter for static-site or documentation generators. The file may contain {{title}} and {{version}} replaceable tags.",
         "required": false
       },
       "outFilename": {
@@ -76,8 +76,9 @@
         "default": "asyncapi.md",
         "required": false
       },
-      "slate": {
-        "description": "Include Slate YAML frontmatter in the output markdown. Disables markdown ToC. See https://github/slatedocs/slate",
+      "toc": {
+        "description": "Include a Table-of-Contents in the output markdown.",
+        "default": "true",
         "required": false
       },
       "version": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@asyncapi/generator-filters": "^1.1.0",
-    "@asyncapi/generator-react-sdk": "^0.1.6"
+    "@asyncapi/generator-react-sdk": "^0.1.6",
+    "yaml": "^1.10.0"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^8.0.1",
@@ -66,9 +67,17 @@
     "renderer": "react",
     "generator": ">=1.1.0 <2.0.0",
     "parameters": {
+      "frontMatter": {
+        "description": "The name of a JSON or YAML formatted file containing values to override the default YAML frontmatter.",
+        "required": false
+      },
       "outFilename": {
         "description": "The name of the output markdown file",
         "default": "asyncapi.md",
+        "required": false
+      },
+      "slate": {
+        "description": "Include Slate YAML frontmatter in the output markdown. Disables markdown ToC. See https://github/slatedocs/slate",
         "required": false
       },
       "version": {

--- a/template/asyncapi.js
+++ b/template/asyncapi.js
@@ -4,12 +4,14 @@ import { Header, Link, ListItem } from "../components/common";
 import { Info, TermsOfService } from "../components/Info";
 import { Servers } from "../components/Servers";
 import { Channels } from "../components/Channels";
+import { FrontMatter } from "../components/FrontMatter";
 
 export default function({ asyncapi, params }) {
   return (
     <File name={params.outFilename || 'asyncapi.md'}>
+      <FrontMatter asyncapi={asyncapi} params={params} />
       <Info asyncapi={asyncapi} params={params} />
-      <TableOfContents asyncapi={asyncapi} />
+      <TableOfContents asyncapi={asyncapi} params={params} />
       <TermsOfService asyncapi={asyncapi} />
       <Servers asyncapi={asyncapi} />
       <Channels asyncapi={asyncapi} />
@@ -17,7 +19,8 @@ export default function({ asyncapi, params }) {
   );
 }
 
-function TableOfContents({ asyncapi }) {
+function TableOfContents({ asyncapi, params }) {
+  if (params.slate) return '';
   return (
     <>
       <Header type={2}>Table of Contents</Header>

--- a/template/asyncapi.js
+++ b/template/asyncapi.js
@@ -11,7 +11,7 @@ export default function({ asyncapi, params }) {
     <File name={params.outFilename || 'asyncapi.md'}>
       <FrontMatter asyncapi={asyncapi} params={params} />
       <Info asyncapi={asyncapi} params={params} />
-      <TableOfContents asyncapi={asyncapi} params={params} />
+      {!params.slate && <TableOfContents asyncapi={asyncapi} />}
       <TermsOfService asyncapi={asyncapi} />
       <Servers asyncapi={asyncapi} />
       <Channels asyncapi={asyncapi} />

--- a/template/asyncapi.js
+++ b/template/asyncapi.js
@@ -9,9 +9,9 @@ import { FrontMatter } from "../components/FrontMatter";
 export default function({ asyncapi, params }) {
   return (
     <File name={params.outFilename || 'asyncapi.md'}>
-      <FrontMatter asyncapi={asyncapi} params={params} />
+      {params.frontMatter && <FrontMatter asyncapi={asyncapi} params={params} />}
       <Info asyncapi={asyncapi} params={params} />
-      {!params.slate && <TableOfContents asyncapi={asyncapi} />}
+      {params.toc !== 'false' && <TableOfContents asyncapi={asyncapi} params={params}/>}
       <TermsOfService asyncapi={asyncapi} />
       <Servers asyncapi={asyncapi} />
       <Channels asyncapi={asyncapi} />
@@ -20,7 +20,6 @@ export default function({ asyncapi, params }) {
 }
 
 function TableOfContents({ asyncapi, params }) {
-  if (params.slate) return '';
   return (
     <>
       <Header type={2}>Table of Contents</Header>

--- a/template/asyncapi.js
+++ b/template/asyncapi.js
@@ -11,7 +11,7 @@ export default function({ asyncapi, params }) {
     <File name={params.outFilename || 'asyncapi.md'}>
       {params.frontMatter && <FrontMatter asyncapi={asyncapi} params={params} />}
       <Info asyncapi={asyncapi} params={params} />
-      {params.toc !== 'false' && <TableOfContents asyncapi={asyncapi} params={params}/>}
+      {params.toc !== 'false' && <TableOfContents asyncapi={asyncapi} />}
       <TermsOfService asyncapi={asyncapi} />
       <Servers asyncapi={asyncapi} />
       <Channels asyncapi={asyncapi} />
@@ -19,7 +19,7 @@ export default function({ asyncapi, params }) {
   );
 }
 
-function TableOfContents({ asyncapi, params }) {
+function TableOfContents({ asyncapi }) {
   return (
     <>
       <Header type={2}>Table of Contents</Header>

--- a/test/spec/asyncapi.yml
+++ b/test/spec/asyncapi.yml
@@ -96,7 +96,7 @@ channels:
         $ref: '#/components/messages/dimLight'
   some.channel:
     subscribe:
-      description: this doesn't show in markdown!
+      description: this description shows in markdown
       message:
         oneOf:
           - $ref: '#/components/messages/successMessage'

--- a/test/spec/slate.yaml
+++ b/test/spec/slate.yaml
@@ -1,5 +1,9 @@
 ---
-title: My AsyncAPI
+
+# example of a frontMatter file for the Slate documentation generator
+# see https://github.com/Slatedocs/Slate
+
+title: '{{title}} version {{version}}'
 language_tabs: [ { shell: "Shell" }, { javascript: "Node.js" } ]
 toc_footers: [ "Built with AsyncAPI/Generator" ]
 includes: []

--- a/test/spec/slate.yaml
+++ b/test/spec/slate.yaml
@@ -1,0 +1,7 @@
+---
+title: My AsyncAPI
+language_tabs: [ { shell: "Shell" }, { javascript: "Node.js" } ]
+toc_footers: [ "Built with AsyncAPI/Generator" ]
+includes: []
+search: true
+code_clipboard: true

--- a/test/spec/ssg.yaml
+++ b/test/spec/ssg.yaml
@@ -2,6 +2,6 @@
 
 # example of a frontMatter file for a static site generator
 
-title: '{{title}} version {{version}}'
+title: AsyncAPI Documentation
 layout: asyncapi
 permalink: /asyncapi-docs

--- a/test/spec/ssg.yaml
+++ b/test/spec/ssg.yaml
@@ -1,0 +1,7 @@
+---
+
+# example of a frontMatter file for a static site generator
+
+title: '{{title}} version {{version}}'
+layout: asyncapi
+permalink: /asyncapi-docs


### PR DESCRIPTION
**Description**

- Adds support for Slate default frontmatter, and support generally for YAML frontmatter (such as setting `layout` / `permalink` etc properties for static-site generators)

**Related issue(s)**
* Resolves #40 

**Preview**

* https://mikeralphson.github.io/agdemo/

Unconditionally changes examples headings from `<h6>` to `<blockquote>` - could be configurable.