### PR TITLE
fix: properties should be optional for items property

### DIFF
--- a/components/Schema.js
+++ b/components/Schema.js
@@ -62,7 +62,7 @@ function SchemaProp({ prop, propName, required = false, path = '', description =
       <SchemaProp prop={p} propName={pName} path={buildPath(path || propName, pName)} required={isRequired(prop.additionalProperties(), pName)} />
     )) : null;
   
-  const items = prop.items() && prop.items().properties()
+  const items = prop.items() && prop.items().properties && prop.items().properties()
     ? Object.entries(prop.items().properties()).map(([pName, p]) => {
       const isCirc = p.isCircular();
 

--- a/components/Schema.js
+++ b/components/Schema.js
@@ -62,7 +62,7 @@ function SchemaProp({ prop, propName, required = false, path = '', description =
       <SchemaProp prop={p} propName={pName} path={buildPath(path || propName, pName)} required={isRequired(prop.additionalProperties(), pName)} />
     )) : null;
   
-  const items = prop.items() && prop.items().properties && prop.items().properties()
+  const items = prop.items() && !Array.isArray(prop.items()) && prop.items().properties()
     ? Object.entries(prop.items().properties()).map(([pName, p]) => {
       const isCirc = p.isCircular();
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- [dummy file](https://raw.githubusercontent.com/asyncapi/generator/master/test/docs/dummy.yml) fails now as items is not necessarily an object, it can also be an array