### PR TITLE
docs: add instructions for using AsyncAPI CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,30 @@
 
 <!-- toc -->
 
-- [Usage](#usage)
-- [Supported parameters](#supported-parameters)
-- [Development](#development)
-- [Contributors ✨](#contributors-%E2%9C%A8)
+- [Markdown template for the AsyncAPI Generator](#markdown-template-for-the-asyncapi-generator)
+  - [Usage](#usage)
+  - [Supported parameters](#supported-parameters)
+  - [Development](#development)
+  - [Contributors ✨](#contributors-)
 
 <!-- tocstop -->
 
 ## Usage
 
-```bash
-ag asyncapi.yaml @asyncapi/markdown-template -o output
-```
-
-If you don't have the AsyncAPI Generator installed, you can install it like this:
+Install AsyncAPI CLI
 
 ```bash
-npm install -g @asyncapi/generator
+npm install -g @asyncapi/cli
 ```
+
+Generate using CLI 
+
+```bash
+asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/markdown-template@1.2.1
+```
+
+You can replace `<asyncapi.yaml>` with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
+Look into [Releases](/asyncapi/markdown-template/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters
 


### PR DESCRIPTION
**Description**
Previously the README contained instructions on how to use the markdown-template using Generator. I have added instructions on an alternate way of using the template using the AsyncAPI CLI.

**Related issue(s)**
See: [#433](https://github.com/asyncapi/html-template/pull/433)

Tagging @derberg 