### PR TITLE
docs: fix link to example asyncapi document

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Generate using CLI
 asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/markdown-template@1.2.1
 ```
 
-You can replace `<asyncapi.yaml>` with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml).
+You can replace `<asyncapi.yaml>` with local path or URL pointing to any AsyncAPI document like [this one](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka-asyncapi.yml).
 Look into [Releases](/asyncapi/markdown-template/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Generate using CLI
 asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/markdown-template@1.2.1
 ```
 
-You can replace `<asyncapi.yaml>` with local path or URL pointing to any AsyncAPI document like [this one](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka-asyncapi.yml).
+You can replace `<asyncapi.yaml>` with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka-asyncapi.yml).
 Look into [Releases](/asyncapi/markdown-template/releases) of this template to pick up the version you need. It is not recommended to always use the latest in production. Always use a specific version.
 
 ## Supported parameters


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- the link in README.md refers to an old filename - the example YAML file in `asyncapi/spec` has been renamed.
- also make it more clear that the link is an example of an AsyncAPI document

---
Old link: [https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka.yml)
New link: [https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka-asyncapi.yml](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka-asyncapi.yml)

**Related issue(s)**
none yet
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->