### PR TITLE
fix: template output for send and receive operations fixed

### DIFF
--- a/components/Operations.js
+++ b/components/Operations.js
@@ -234,7 +234,7 @@ function OperationReply({ operation, type }) {
       </Header>
 
       {explicitChannel?.address() ? (
-        <ListItem>{type} should be done to channel: `{explicitChannel.address()}`</ListItem>
+        <ListItem>{type} will be provided via this designated address: `{explicitChannel.address()}`</ListItem>
       ) : (
         <OperationReplyAddress name="Operation reply address" reply={reply} />
       )}

--- a/test/components/__snapshots__/Operations.test.js.snap
+++ b/test/components/__snapshots__/Operations.test.js.snap
@@ -265,7 +265,7 @@ A longer description of the message
 
 #### Response information
 
-* reply should be done to channel: \`user/signedup\`
+* reply will be provided via this designated address: \`user/signedup\`
 #### Message \`SomeReplyMessage\`
 
 A longer description of the message
@@ -333,7 +333,7 @@ A longer description of the message
 
 #### Request information
 
-* request should be done to channel: \`user/signedup\`
+* request will be provided via this designated address: \`user/signedup\`
 #### Message \`SomeReplyMessage\`
 
 A longer description of the message


### PR DESCRIPTION
**Description**

This PR introduces the changes to fix the markdown-template output for the send and receive operations and make it consistent with other templates as like HTML template.

Tests have been also updated as well and are all passing.

![image](https://github.com/user-attachments/assets/c3a7d004-9dd5-4ece-a4d0-e8f597fd0f17)


**Related issue(s)**

Resolves #594 


@derberg can you please review the PR and provide feedback.

Thanks.