### PR TITLE
feat!: release new markdown template compatible with generator v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install -g @asyncapi/cli
 Generate using CLI 
 
 ```bash
-asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/markdown-template@1.2.1
+asyncapi generate fromTemplate <asyncapi.yaml> @asyncapi/markdown-template@2.0.0
 ```
 
 You can replace `<asyncapi.yaml>` with local path or URL pointing to [any AsyncAPI document](https://raw.githubusercontent.com/asyncapi/spec/master/examples/streetlights-kafka-asyncapi.yml).
@@ -44,12 +44,7 @@ Look into [Releases](/asyncapi/markdown-template/releases) of this template to p
 
 ## Development
 
-1. Make sure you have the latest generator installed `npm install -g @asyncapi/generator`.
-2. Modify the template or it's reusable parts. Adjust `test/spec/asyncapi.yml` to have more complexity if needed.
-3. Generate output with watcher enabled by running the command `npm run dev`.
-4. Check generated markdown file located in `./test/output/asyncapi.md`.
-
-Parameters for the template are defined in `package.json`.
+The best and most reliable way of developing template is by using Generator's build in CLI. Clone Generator and follow official [development guide](https://github.com/asyncapi/generator/blob/master/Development.md#manually-testing-with-test-templates).
 
 ## Contributors ✨
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,8 @@
   "homepage": "https://github.com/asyncapi/markdown-template#readme",
   "scripts": {
     "start": "npm run test:generator:v2",
-    "test": "npm run test:library && npm run test:generator",
+    "test": "npm run test:library",
     "test:library": "jest --coverage",
-    "test:generator": "npm run test:generator:v2 && npm run test:generator:v3",
-    "test:generator:v2": "asyncapi generate fromTemplate ./test/spec/asyncapi_v2.yml ./ -o test/output --force-write",
-    "test:generator:v3": "asyncapi generate fromTemplate ./test/spec/asyncapi_v3.yml ./ -o test/output --force-write",
-    "dev": "asyncapi generate fromTemplate ./test/spec/asyncapi_v2.yml ./ -o test/output --force-write --watch-template",
     "lint": "eslint --max-warnings 0 --config \".eslintrc\" \".\"",
     "lint:fix": "eslint --max-warnings 0 --config \".eslintrc\" \".\" --fix",
     "generate:assets": "npm run generate:readme:toc",
@@ -41,7 +37,6 @@
     "yaml": "^1.10.2"
   },
   "devDependencies": {
-    "@asyncapi/cli": "^3.1.1",
     "@asyncapi/parser": "^3.1.0",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
@@ -58,7 +53,7 @@
   "generator": {
     "renderer": "react",
     "apiVersion": "v3",
-    "generator": ">=1.15.0 <2.0.0",
+    "generator": ">=3.0.0 <4.0.0",
     "parameters": {
       "frontMatter": {
         "description": "The name of a JSON or YAML formatted file containing values to provide the YAML frontmatter for static-site or documentation generators. The file may contain {{title}} and {{version}} replaceable tags.",


### PR DESCRIPTION
removing tests based on cli as they do not make sense cause release flow is generator -> cli -> templates, and at the moment cli tests depend on markdown template, so markdown template must actually be released before cli, therefore cannot be tested with cli