### PR TITLE
feat!: major release of template to support latest v3 generator

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -120,7 +120,7 @@ jobs:
         run: npm ci
       - if: steps.packagejson.outputs.exists == 'true'
         name: Add plugin for conventional commits for semantic-release
-        run: npm install --save-dev conventional-changelog-conventionalcommits@5.0.0
+        run: npm install --save-dev conventional-changelog-conventionalcommits@9.1.0
       - if: steps.packagejson.outputs.exists == 'true'
         name: Publish to any of NPM, Github, and Docker Hub
         id: release


### PR DESCRIPTION
https://github.com/asyncapi/markdown-template/pull/654 did not trigger major

there was a gap in https://github.com/asyncapi/community/issues/2175 instruction - plugin that understands `!` as major release indicator had to be updated